### PR TITLE
fix: key error for ignoreDataGaps default payload param

### DIFF
--- a/amc_quickstart/microservices/platform_management_service/platform_manager/-Getting_Started-.ipynb
+++ b/amc_quickstart/microservices/platform_management_service/platform_manager/-Getting_Started-.ipynb
@@ -290,7 +290,10 @@
     "timeWindowType = \"EXPLICIT\"\n",
     "\n",
     "# OPTIONAL: Change to your desired Workflow Executed Date\n",
-    "workflowExecutedDate = \"now()\"\n"
+    "workflowExecutedDate = \"now()\"\n",
+    "\n",
+    "# OPTIONAL: Change to False\n",
+    "ignoreDataGaps: True"
    ]
   },
   {

--- a/amc_quickstart/microservices/platform_management_service/platform_manager/Workflow_Library.ipynb
+++ b/amc_quickstart/microservices/platform_management_service/platform_manager/Workflow_Library.ipynb
@@ -82,7 +82,7 @@
     "            \"timeWindowStart\": '' ,\n",
     "            \"timeWindowType\": '' ,\n",
     "            \"workflowExecutedDate\": '',\n",
-    "#           \"ignoreDataGaps\": True\n",
+    "            \"ignoreDataGaps\": True\n",
     "    }\n",
     "}\n",
     "\n",
@@ -144,10 +144,21 @@
   }
  ],
  "metadata": {
-  "language_info": {
-   "name": "python"
+  "kernelspec": {
+   "display_name": "amc-insights",
+   "language": "python",
+   "name": "python3"
   },
-  "orig_nbformat": 4
+  "language_info": {
+   "name": "python",
+   "version": "3.10.3 (main, Mar 29 2022, 11:42:49) [Clang 13.1.6 (clang-1316.0.21.2)]"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "40ec9b8a0674637d910db8619ba3f1edb1c41b7ab1d9e9c6b03cbee6008de5a1"
+   }
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/amc_quickstart/microservices/platform_management_service/platform_manager/Workflows.ipynb
+++ b/amc_quickstart/microservices/platform_management_service/platform_manager/Workflows.ipynb
@@ -101,7 +101,7 @@
     "            \"timeWindowStart\": '' ,\n",
     "            \"timeWindowType\": '' ,\n",
     "            \"workflowExecutedDate\": '',\n",
-    "#           \"ignoreDataGaps\": True\n",
+    "            \"ignoreDataGaps\": True\n",
     "    }\n",
     "}"
    ]
@@ -200,7 +200,7 @@
   },
   "language_info": {
    "name": "python",
-   "version": "3.10.3"
+   "version": "3.10.3 (main, Mar 29 2022, 11:42:49) [Clang 13.1.6 (clang-1316.0.21.2)]"
   },
   "orig_nbformat": 4
  },

--- a/amc_quickstart/microservices/platform_management_service/platform_manager/library/platform_utils.py
+++ b/amc_quickstart/microservices/platform_management_service/platform_manager/library/platform_utils.py
@@ -65,7 +65,8 @@ class PlatformUtilities():
             default_parameters = {}
             for param in parameters:
                 try:
-                    val = response['Item']['defaultPayload']['M'][param]['S']
+                    item = response['Item']['defaultPayload']['M'][param]
+                    val = list(item.values())[0]
                     default_parameters[param] = val
                 except Exception as e:
                     print(f'ERROR: No default value set for {e} \nSet default value in the AMCWorkflows table or invoke with payload\n')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Quickfix bug preventing users from running a workflow without passing in `ignoreDataGaps` as a payload override

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
